### PR TITLE
feat(dnf): dnf5 addRepo fix + expanded test coverage

### DIFF
--- a/dnf/capabilities.go
+++ b/dnf/capabilities.go
@@ -90,7 +90,7 @@ func (d *DNF) ListRepos(ctx context.Context) ([]snack.Repository, error) {
 func (d *DNF) AddRepo(ctx context.Context, repo snack.Repository) error {
 	d.Lock()
 	defer d.Unlock()
-	return addRepo(ctx, repo)
+	return addRepo(ctx, repo, d.v5)
 }
 
 // RemoveRepo removes a configured repository.

--- a/dnf/capabilities_linux.go
+++ b/dnf/capabilities_linux.go
@@ -171,8 +171,14 @@ func listRepos(ctx context.Context, v5 bool) ([]snack.Repository, error) {
 	return parseRepoList(out), nil
 }
 
-func addRepo(ctx context.Context, repo snack.Repository) error {
-	_, err := run(ctx, []string{"config-manager", "--add-repo", repo.URL}, snack.Options{})
+func addRepo(ctx context.Context, repo snack.Repository, v5 bool) error {
+	var args []string
+	if v5 {
+		args = []string{"config-manager", "addrepo", "--from-repofile=" + repo.URL}
+	} else {
+		args = []string{"config-manager", "--add-repo", repo.URL}
+	}
+	_, err := run(ctx, args, snack.Options{})
 	return err
 }
 

--- a/dnf/capabilities_other.go
+++ b/dnf/capabilities_other.go
@@ -56,7 +56,7 @@ func listRepos(_ context.Context, _ bool) ([]snack.Repository, error) {
 	return nil, snack.ErrUnsupportedPlatform
 }
 
-func addRepo(_ context.Context, _ snack.Repository) error {
+func addRepo(_ context.Context, _ snack.Repository, _ bool) error {
 	return snack.ErrUnsupportedPlatform
 }
 

--- a/dnf/dnf_integration_test.go
+++ b/dnf/dnf_integration_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIntegration_DNF_Detection(t *testing.T) {
+	d := dnf.New()
+	if !d.Available() {
+		t.Skip("dnf not available")
+	}
+	t.Logf("IsDNF5: %v", d.IsDNF5())
+}
+
 func TestIntegration_DNF(t *testing.T) {
 	var mgr snack.Manager = dnf.New()
 	if !mgr.Available() {
@@ -105,6 +113,18 @@ func TestIntegration_DNF(t *testing.T) {
 			groups, err := g.GroupList(ctx)
 			require.NoError(t, err)
 			_ = groups
+		}
+
+		if rm, ok := mgr.(snack.RepoManager); ok {
+			repos, err := rm.ListRepos(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, repos, "should have at least one repo")
+			t.Logf("repos: %d", len(repos))
+		}
+
+		if nn, ok := mgr.(snack.NameNormalizer); ok {
+			got := nn.NormalizeName("curl.x86_64")
+			assert.Equal(t, "curl", got)
 		}
 	})
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -57,8 +57,14 @@ var distros = []distroTest{
 		packages: "./pacman/ ./detect/",
 	},
 	{
-		name:     "fedora-dnf",
+		name:     "fedora-dnf4",
 		image:    "fedora:39",
+		setup:    installGo("dnf install -y tree sudo wget"),
+		packages: "./dnf/ ./rpm/ ./detect/",
+	},
+	{
+		name:     "fedora-dnf5",
+		image:    "fedora:latest",
 		setup:    installGo("dnf install -y tree sudo wget"),
 		packages: "./dnf/ ./rpm/ ./detect/",
 	},


### PR DESCRIPTION
## Changes

- **Fix dnf5 addRepo**: dnf5 uses `config-manager addrepo --from-repofile=URL` instead of dnf4's `config-manager --add-repo URL`
- **Containertest matrix**: Add `fedora:latest` (dnf5) alongside `fedora:39` (dnf4)
- **Integration tests**: Add `IsDNF5` detection test, `RepoManager.ListRepos`, `NameNormalizer.NormalizeName`

Addresses part of #15 (dnf5 support).