### PR TITLE
fix(detect): normalize ByName input

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ if err != nil {
     log.Fatal(err)
 }
 fmt.Println("Detected:", mgr.Name())
+
+aptMgr, err := detect.ByName(" APT ")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Requested:", aptMgr.Name())
 ```
 
 ## Interfaces

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -3,6 +3,7 @@ package detect
 
 import (
 	"os/exec"
+	"strings"
 	"sync/atomic"
 
 	"github.com/gogrlx/snack"
@@ -56,11 +57,13 @@ func All() []snack.Manager {
 }
 
 // ByName returns a specific manager by name, regardless of availability.
+// Name matching is case-insensitive and ignores surrounding whitespace.
 // Returns ErrManagerNotFound if the name is not recognized.
 func ByName(name string) (snack.Manager, error) {
+	needle := strings.ToLower(strings.TrimSpace(name))
 	for _, fn := range allManagers() {
 		m := fn()
-		if m.Name() == name {
+		if m.Name() == needle {
 			return m, nil
 		}
 	}

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -36,6 +36,16 @@ func TestByNameKnown(t *testing.T) {
 	}
 }
 
+func TestByNameNormalizesInput(t *testing.T) {
+	m, err := ByName("  APT\n")
+	if err != nil {
+		t.Fatalf("ByName normalized input returned error: %v", err)
+	}
+	if m.Name() != "apt" {
+		t.Errorf("ByName normalized input Name() = %q, want %q", m.Name(), "apt")
+	}
+}
+
 func TestByNameReturnsCorrectType(t *testing.T) {
 	m, err := ByName("apt")
 	if err != nil {


### PR DESCRIPTION
## Summary
- normalize detect.ByName input by trimming whitespace and folding case
- add a regression test covering mixed-case, padded input
- document the relaxed ByName lookup in the README auto-detection example

## Testing
- go test ./...