### PR TITLE
test(normalize): cover manager helper edge cases

### DIFF
--- a/brew/brew_test.go
+++ b/brew/brew_test.go
@@ -139,6 +139,7 @@ func TestNormalizeName(t *testing.T) {
 		{"node@18", "node"},
 		{"go", "go"},
 		{"ruby@3.2", "ruby"},
+		{"postgresql@16@beta", "postgresql@16"},
 	}
 
 	b := New()
@@ -347,6 +348,7 @@ func TestParseVersionSuffix(t *testing.T) {
 		{"node@18", "node", "18"},
 		{"git", "git", ""},
 		{"ruby@3.2", "ruby", "3.2"},
+		{"postgresql@16@beta", "postgresql@16", "beta"},
 		{"", "", ""},
 		{"@3.12", "@3.12", ""}, // @ at position 0, LastIndex returns 0 which is not > 0
 	}

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -455,3 +455,49 @@ func TestName(t *testing.T) {
 		t.Errorf("Name() = %q, want %q", s.Name(), "snap")
 	}
 }
+
+func TestNormalizeName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"firefox", "firefox"},
+		{"hello-world", "hello-world"},
+		{"snap.with.dots", "snap.with.dots"},
+		{"  keep-whitespace  ", "  keep-whitespace  "},
+		{"", ""},
+	}
+
+	s := New()
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := s.NormalizeName(tt.input); got != tt.want {
+				t.Errorf("NormalizeName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseArch(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantName string
+		wantArch string
+	}{
+		{"firefox", "firefox", ""},
+		{"hello-world", "hello-world", ""},
+		{"snap.with.dots", "snap.with.dots", ""},
+		{"", "", ""},
+	}
+
+	s := New()
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotName, gotArch := s.ParseArch(tt.input)
+			if gotName != tt.wantName || gotArch != tt.wantArch {
+				t.Errorf("ParseArch(%q) = (%q, %q), want (%q, %q)",
+					tt.input, gotName, gotArch, tt.wantName, tt.wantArch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add snap normalization and parse-arch coverage for passthrough behavior
- extend brew version-suffix coverage for nested @ suffixes
- keep Round 3 scoped to missing tests because existing PRs were already clean and green

## Testing
- go test ./...