### PR TITLE
test(snap): cover raw arch parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gogrlx/snack
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/charmbracelet/fang v1.0.0

--- a/integration_test.go
+++ b/integration_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-const goVersion = "1.26.0"
+const goVersion = "1.26.4"
 
 // distroTest describes a container environment and the test packages available in it.
 type distroTest struct {

--- a/snap/snap_test.go
+++ b/snap/snap_test.go
@@ -493,6 +493,12 @@ func TestParseArch(t *testing.T) {
 	s := New()
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
+			rawName, rawArch := parseArch(tt.input)
+			if rawName != tt.wantName || rawArch != tt.wantArch {
+				t.Errorf("parseArch(%q) = (%q, %q), want (%q, %q)",
+					tt.input, rawName, rawArch, tt.wantName, tt.wantArch)
+			}
+
 			gotName, gotArch := s.ParseArch(tt.input)
 			if gotName != tt.wantName || gotArch != tt.wantArch {
 				t.Errorf("ParseArch(%q) = (%q, %q), want (%q, %q)",


### PR DESCRIPTION
## Summary
- bump the module Go directive to the latest published Go patch release, `1.26.4`
- align the container integration test tarball version with `1.26.4`
- exercise the raw Snap `parseArch` helper through the existing normalization test table

## Verification
- `go generate ./...`
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...`
- `go test -race ./...`
- `go test -cover ./...`
