### PR TITLE
test(linux): cover snap and flatpak command wrappers

### DIFF
--- a/flatpak/flatpak_linux_test.go
+++ b/flatpak/flatpak_linux_test.go
@@ -1,0 +1,68 @@
+//go:build linux
+
+package flatpak
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogrlx/snack"
+)
+
+func TestAvailableWithFakeFlatpak(t *testing.T) {
+	writeFakeFlatpak(t, "exit 0\n")
+
+	if !available() {
+		t.Fatal("expected fake flatpak to be available")
+	}
+}
+
+func TestListReposUsesFlatpakRemotesOutput(t *testing.T) {
+	writeFakeFlatpak(t, `if [ "$1" = "remotes" ]; then
+	printf 'flathub\thttps://dl.flathub.org/repo/\t\n'
+	printf 'nightly\thttps://nightly.gnome.org/repo/\tdisabled\n'
+	exit 0
+fi
+exit 2
+`)
+
+	repos, err := New().ListRepos(context.Background())
+	if err != nil {
+		t.Fatalf("ListRepos returned error: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if repos[0].ID != "flathub" || repos[0].URL != "https://dl.flathub.org/repo/" || !repos[0].Enabled {
+		t.Errorf("unexpected first repo: %+v", repos[0])
+	}
+	if repos[1].ID != "nightly" || repos[1].Enabled {
+		t.Errorf("unexpected second repo: %+v", repos[1])
+	}
+}
+
+func TestRunMapsPermissionDenied(t *testing.T) {
+	writeFakeFlatpak(t, `printf 'permission denied\n' >&2
+exit 1
+`)
+
+	_, err := run(context.Background(), []string{"install", "flathub", "org.example.App"})
+	if !errors.Is(err, snack.ErrPermissionDenied) {
+		t.Fatalf("expected ErrPermissionDenied, got %v", err)
+	}
+}
+
+func writeFakeFlatpak(t *testing.T, body string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flatpak")
+	script := "#!/bin/sh\n" + body
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake flatpak: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/snap/snap_linux_test.go
+++ b/snap/snap_linux_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package snap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAvailableRequiresSnapVersion(t *testing.T) {
+	writeFakeSnap(t, `if [ "$1" = "version" ]; then
+	exit 0
+fi
+exit 2
+`)
+
+	if !available() {
+		t.Fatal("expected fake snap with version support to be available")
+	}
+}
+
+func TestListUpgradesTreatsAllUpToDateErrorAsEmpty(t *testing.T) {
+	writeFakeSnap(t, `if [ "$1" = "refresh" ] && [ "$2" = "--list" ]; then
+	printf 'All snaps up to date.\n' >&2
+	exit 1
+fi
+exit 2
+`)
+
+	upgrades, err := New().ListUpgrades(context.Background())
+	if err != nil {
+		t.Fatalf("ListUpgrades returned error: %v", err)
+	}
+	if len(upgrades) != 0 {
+		t.Fatalf("expected no upgrades, got %d", len(upgrades))
+	}
+}
+
+func TestCleanRemovesDisabledRevisions(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "snap.log")
+	writeFakeSnap(t, `if [ "$1" = "list" ] && [ "$2" = "--all" ]; then
+	printf 'Name Version Rev Tracking Publisher Notes\n'
+	printf 'core22 20240111 1122 latest/stable canonical disabled\n'
+	printf 'firefox 131.0 4647 latest/stable mozilla -\n'
+	exit 0
+fi
+if [ "$1" = "remove" ]; then
+	printf '%s %s %s\n' "$1" "$2" "$3" >> "$SNAP_TEST_LOG"
+	exit 0
+fi
+exit 2
+`)
+	t.Setenv("SNAP_TEST_LOG", logPath)
+
+	if err := New().Clean(context.Background()); err != nil {
+		t.Fatalf("Clean returned error: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read snap command log: %v", err)
+	}
+	got := strings.TrimSpace(string(logBytes))
+	if got != "remove core22 --revision=1122" {
+		t.Fatalf("unexpected snap remove call %q", got)
+	}
+}
+
+func writeFakeSnap(t *testing.T, body string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snap")
+	script := "#!/bin/sh\n" + body
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake snap: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}


### PR DESCRIPTION
## Summary
- add Linux fake-binary coverage for flatpak availability, remotes parsing, and permission errors
- add Linux fake-binary coverage for snap availability, all-up-to-date refresh handling, and disabled revision cleanup

## Tests
- go generate ./...
- go test -race ./...
- staticcheck ./...